### PR TITLE
Fix two small typo's

### DIFF
--- a/templates/home.erb
+++ b/templates/home.erb
@@ -62,7 +62,7 @@
             <img src="images/Certificate-64.png" />
             <h2>Support Your Own DSL</h2>
             <span class="preview">&rarr;</span>
-            <p>You can write all kinds of extensions in YARD, including ones that can understand all of the dynamic magic your framework does in its own little Doman Specific Languages (DSLs). Most importantly, it's <a href="guides/extending-yard/writing-handlers.html">really easy</a> to do! There are already plugins that support frameworks like <a href="http://rspec.info">RSpec</a>, <a href="http://datamapper.org">DataMapper</a>, <a href="http://www.sinatrarb.com">Sinatra</a>, and support for others are in the works.</p>
+            <p>You can write all kinds of extensions in YARD, including ones that can understand all of the dynamic magic your framework does in its own little Domain Specific Languages (DSLs). Most importantly, it's <a href="guides/extending-yard/writing-handlers.html">really easy</a> to do! There are already plugins that support frameworks like <a href="http://rspec.info">RSpec</a>, <a href="http://datamapper.org">DataMapper</a>, <a href="http://www.sinatrarb.com">Sinatra</a>, and support for others are in the works.</p>
             <span class="image" style="background-image: url(images/ss8.png);"></span>
           </div>
         </div>
@@ -137,7 +137,7 @@
           </div>
           <div class="column support">
             <h2>Contributing &amp; Support</h2>
-            <p>If you're interesting in helping out, you can use the following methods to get in touch:</p>
+            <p>If you're interested in helping out, you can use the following methods to get in touch:</p>
             <ul>
               <li>IRC: <tt><a href="irc://irc.freenode.net/yard">#yard</a></tt> on <tt>irc.freenode.net</tt>.</li> 
               <li>Mailing list: <a href="http://groups.google.com/group/yardoc">http://groups.google.com/group/yardoc</a></li> 


### PR DESCRIPTION
When I looked at the yardoc.org homepage, I noticed two small typo's. I figured it wouldn't be too much trouble to fix 'em myself :smile:
