### PR TITLE
Fix links to other projects and remove wiki link

### DIFF
--- a/templates/home.erb
+++ b/templates/home.erb
@@ -115,21 +115,20 @@
           <div class="column uses">
             <h2>Who Uses YARD?</h2>
             <p>YARD is used in a wide variety of projects including personal ones that we don't know about, but here are some projects that we know do:</p>
-            <p><a href='http://addressable.rubyforge.org/'>Addressable</a>, <a href='http://amp.carboni.ca/'>Amp</a>, 
+            <p><a href='https://github.com/sporkmonger/addressable'>Addressable</a>, <a href='http://amp.carboni.ca/'>Amp</a>, 
               <a href='http://crm114.rubyforge.org/'>CRM114.rb</a>, <a href='http://datamapper.org/'>DataMapper</a>, 
               <a href='http://github.com/robgleeson/dia'>Dia</a>, 
-              <a href='http://haml-lang.com/'>Haml</a>, 
+              <a href='http://haml.info/'>Haml</a>, 
               <a href='http://tagaholic.me/lightning'>lightning</a>, 
               <a href='http://github.com/mongodb/mongo-ruby-driver'>MongoDB</a>, 
-              <a href='http://nanoc.stoneship.org/'>nanoc</a>, 
+              <a href='http://nanoc.ws/'>nanoc</a>, 
               <a href='http://ohm.keyvalue.org/'>Ohm</a>, 
-              <a href='http://www.puppetlabs.com/'>Puppet</a>, 
-              <a href='http://ronin-ruby.github.com/'>Ronin</a>, 
+              <a href='https://puppet.com/'>Puppet</a>, 
+              <a href='http://ronin-ruby.github.io/'>Ronin</a>, 
               <a href='http://sass-lang.com/'>Sass</a>, 
               <a href='http://spidr.rubyforge.org/'>Spidr</a>, 
-              <a href='http://giantrobots.thoughtbot.com/2009/6/4/documentation-demolition-derby'>thoughtbot</a>, 
+              <a href='https://robots.thoughtbot.com/documentation-demolition-derby'>thoughtbot</a>, 
               <a href='http://vanity.labnotes.org/'>vanity</a>.
-              A full list can be found <a href="https://github.com/lsegal/yard/wiki/Who's-Using-YARD%3F">here</a>.</p> 
             
             <p>YARD also runs a live documentation server for the community, hosting docs for all RubyGems and Github projects.
               The project is at <a href="http://rubydoc.info">RubyDoc.info</a> (formerly rdoc.info)</p>


### PR DESCRIPTION
Fixed a few of these links to go to the correct sites and removed the link to the wiki that doesn't exist anymore.