### PR TITLE
Fix showing type parsing error

### DIFF
--- a/public/js/types.js
+++ b/public/js/types.js
@@ -153,7 +153,7 @@ class TypesParser {
       return result;
     } catch (e) {
       if (e instanceof SyntaxError) {
-        return e.message;
+        return [e.message];
       }
       throw e;
     }


### PR DESCRIPTION
Before
---

<img width="810" alt="スクリーンショット 2021-02-20 12 18 51" src="https://user-images.githubusercontent.com/1180335/108582325-dd885780-7375-11eb-96f7-befe1d99c7de.png">
<img width="697" alt="スクリーンショット 2021-02-20 12 18 57" src="https://user-images.githubusercontent.com/1180335/108582328-dfeab180-7375-11eb-8b3d-0247a9d7036f.png">

After
---

<img width="1156" alt="スクリーンショット 2021-02-20 12 19 41" src="https://user-images.githubusercontent.com/1180335/108582338-f1cc5480-7375-11eb-99ad-4d435b791137.png">

---

I know this behavior in https://github.com/rspec/rspec-expectations/pull/1292
